### PR TITLE
Post-build Docker Resources Cleanup & Resource Namespacing for Build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-docker-compose build
-docker-compose run builder
-docker-compose down
+docker-compose -p rpibootloaderbuild build
+docker-compose -p rpibootloaderbuild run builder
+docker-compose -p rpibootloaderbuild down

--- a/build.sh
+++ b/build.sh
@@ -3,3 +3,4 @@ set -e
 
 docker-compose build
 docker-compose run builder
+docker-compose down


### PR DESCRIPTION
- Added "docker-compose down" to cleanup the container and docker network after the build is done. Could also add the --rmi option, but that one is less cut and dried, because it means the image will have to be rebuilt again on subsequent builds
- Added pre-defined namespacing to docker resources so that the name is not dependent on the, sometimes badly named, parent directory