### PR TITLE
Made firmware repo composable with a sensible default. Added composable option whether to output artifacts in timestamped directory.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM alpine:3.7
 
 WORKDIR /workdir
-ENV FIRMWARE=/workdir/raspberry-firmware
+ENV FIRMWARE=/workdir/raspberry-firmware \
+    FIRMWARE_REPO=https://www.github.com/raspberrypi/firmware \
+    TIMESTAMP_OUTPUT=true
 
 # Install build dependencies
 RUN apk add --no-cache bash git

--- a/build-tarball.sh
+++ b/build-tarball.sh
@@ -5,7 +5,11 @@ set -x
 # Create target dir for build artefacts
 WORKDIR=$PWD
 BUILD_NR=${BUILD_NR:=$(date '+%Y%m%d-%H%M%S')}
-BUILD_DEST=/builds/$BUILD_NR
+if [ "$TIMESTAMP_OUTPUT" == "true" ]; then
+  BUILD_DEST=/builds/$BUILD_NR
+else
+  BUILD_DEST=/builds
+fi
 mkdir -p $BUILD_DEST
 
 # Clone the upstream GH repo
@@ -17,7 +21,7 @@ if [[ -d $FIRMWARE ]]; then
   git checkout $BRANCH
 else
   # clone repo
-  git clone --single-branch --branch $BRANCH --depth 1 https://www.github.com/raspberrypi/firmware $FIRMWARE
+  git clone --single-branch --branch $BRANCH --depth 1 $FIRMWARE_REPO $FIRMWARE
   cd $FIRMWARE
 fi
 


### PR DESCRIPTION
Added as composable environment variables:
- Firmware repo
- Whether or not to output artifact under timestamped directory

Backward compatible values are set in image, but can now be overridden at run-time.